### PR TITLE
feat(nvim): enable markdown rendering in Octo.nvim buffers

### DIFF
--- a/nvim/lua/plugins/render-markdown.lua
+++ b/nvim/lua/plugins/render-markdown.lua
@@ -10,6 +10,8 @@ return {
             enabled = true,
             -- Maximum file size to render
             max_file_size = 10.0, -- MB
+            -- File types to render
+            file_types = { "markdown", "octo" },
             -- Render mode
             render_modes = { "n", "c" }, -- Normal and command mode
             -- Anti-conceal feature


### PR DESCRIPTION
## Summary
• Add 'octo' filetype to render-markdown.nvim configuration
• Enable markdown rendering in GitHub PR and issue buffers viewed through Octo.nvim
• Improves readability of GitHub content within Neovim

## Test plan
- [ ] Open a PR with Octo.nvim (`<leader>gpr`)
- [ ] Toggle markdown rendering with `<leader>m`
- [ ] Verify markdown elements render properly in PR descriptions
- [ ] Check that existing markdown files still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)